### PR TITLE
Add manager feature

### DIFF
--- a/src/main/java/com/inthebytes/restaurantmanager/control/RestaurantAccountController.java
+++ b/src/main/java/com/inthebytes/restaurantmanager/control/RestaurantAccountController.java
@@ -3,6 +3,7 @@ package com.inthebytes.restaurantmanager.control;
 import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -25,6 +26,8 @@ public class RestaurantAccountController {
 	private RestaurantAccountService service;
 	
 	private ResponseEntity<RestaurantDTO> buildResponse(RestaurantDTO restaurant) {
+//		HttpHeaders headers = new HttpHeaders();
+//		headers.set("Access-Control-Allow-Origin", "http://localhost:4200");
 		if (restaurant == null)
 			return ResponseEntity.notFound().build();
 		return ResponseEntity.ok().body(restaurant);
@@ -32,7 +35,7 @@ public class RestaurantAccountController {
 	
 	@PutMapping(value = "/{restaurantId}/managers")
 	public ResponseEntity<RestaurantDTO> addManager(
-			@PathVariable Long id, 
+			@PathVariable("restaurantId") Long id, 
 			@Valid @RequestBody UserDto user) {
 		
 		RestaurantDTO restaurant = service.addManager(id, user);

--- a/src/main/java/com/inthebytes/restaurantmanager/control/RestaurantAccountController.java
+++ b/src/main/java/com/inthebytes/restaurantmanager/control/RestaurantAccountController.java
@@ -1,0 +1,58 @@
+package com.inthebytes.restaurantmanager.control;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.inthebytes.restaurantmanager.dto.RestaurantDTO;
+import com.inthebytes.restaurantmanager.dto.UserDto;
+import com.inthebytes.restaurantmanager.service.RestaurantManagerService;
+
+@RestController
+@RequestMapping("/apis/restaurants")
+@CrossOrigin("http://localhost:4200")
+public class RestaurantAccountController {
+	
+	@Autowired
+	private RestaurantManagerService service;
+	
+	@PutMapping(value = "/{restaurantId}/managers")
+	public ResponseEntity<RestaurantDTO> addManager(
+			@PathVariable Long id, 
+			@RequestBody UserDto user) {
+		
+		return null;
+	}
+	
+	
+	@PutMapping(value = "/{restaurantId}/managers/{userId}")
+	public ResponseEntity<RestaurantDTO> addManagerById(
+			@PathVariable("restaurantId") Long restaurantId,
+			@PathVariable("userId") Long userId) {
+		
+		return null;
+	}
+	
+	
+	@DeleteMapping(value = "/{restaurantId}/managers")
+	public ResponseEntity<RestaurantDTO> deleteManager(
+			@PathVariable Long id, 
+			@RequestBody UserDto user) {
+		return null;
+	}
+	
+	
+	@DeleteMapping(value = "/{restaurantId}/managers/{userId}")
+	public ResponseEntity<RestaurantDTO> deleteManagerById(
+			@PathVariable("restaurantId") Long restaurantId,
+			@PathVariable("userId") Long userId) {
+		
+		return null;
+	}
+}

--- a/src/main/java/com/inthebytes/restaurantmanager/control/RestaurantAccountController.java
+++ b/src/main/java/com/inthebytes/restaurantmanager/control/RestaurantAccountController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.inthebytes.restaurantmanager.dto.RestaurantDTO;
 import com.inthebytes.restaurantmanager.dto.UserDto;
-import com.inthebytes.restaurantmanager.service.RestaurantManagerService;
+import com.inthebytes.restaurantmanager.service.RestaurantAccountService;
 
 @RestController
 @RequestMapping("/apis/restaurants")
@@ -20,14 +20,21 @@ import com.inthebytes.restaurantmanager.service.RestaurantManagerService;
 public class RestaurantAccountController {
 	
 	@Autowired
-	private RestaurantManagerService service;
+	private RestaurantAccountService service;
+	
+	private ResponseEntity<RestaurantDTO> buildResponse(RestaurantDTO restaurant) {
+		if (restaurant == null)
+			return ResponseEntity.notFound().build();
+		return ResponseEntity.ok().body(restaurant);
+	}
 	
 	@PutMapping(value = "/{restaurantId}/managers")
 	public ResponseEntity<RestaurantDTO> addManager(
 			@PathVariable Long id, 
 			@RequestBody UserDto user) {
 		
-		return null;
+		RestaurantDTO restaurant = service.addManager(id, user);
+		return buildResponse(restaurant);
 	}
 	
 	
@@ -36,7 +43,8 @@ public class RestaurantAccountController {
 			@PathVariable("restaurantId") Long restaurantId,
 			@PathVariable("userId") Long userId) {
 		
-		return null;
+		RestaurantDTO restaurant = service.addManager(restaurantId, userId);
+		return buildResponse(restaurant);
 	}
 	
 	
@@ -44,7 +52,9 @@ public class RestaurantAccountController {
 	public ResponseEntity<RestaurantDTO> deleteManager(
 			@PathVariable Long id, 
 			@RequestBody UserDto user) {
-		return null;
+		
+		RestaurantDTO restaurant = service.removeManager(id, user);
+		return buildResponse(restaurant);
 	}
 	
 	
@@ -53,6 +63,7 @@ public class RestaurantAccountController {
 			@PathVariable("restaurantId") Long restaurantId,
 			@PathVariable("userId") Long userId) {
 		
-		return null;
+		RestaurantDTO restaurant = service.removeManager(restaurantId, userId);
+		return buildResponse(restaurant);
 	}
 }

--- a/src/main/java/com/inthebytes/restaurantmanager/control/RestaurantAccountController.java
+++ b/src/main/java/com/inthebytes/restaurantmanager/control/RestaurantAccountController.java
@@ -26,8 +26,6 @@ public class RestaurantAccountController {
 	private RestaurantAccountService service;
 	
 	private ResponseEntity<RestaurantDTO> buildResponse(RestaurantDTO restaurant) {
-//		HttpHeaders headers = new HttpHeaders();
-//		headers.set("Access-Control-Allow-Origin", "http://localhost:4200");
 		if (restaurant == null)
 			return ResponseEntity.notFound().build();
 		return ResponseEntity.ok().body(restaurant);
@@ -55,10 +53,10 @@ public class RestaurantAccountController {
 	
 	@DeleteMapping(value = "/{restaurantId}/managers")
 	public ResponseEntity<RestaurantDTO> deleteManager(
-			@PathVariable Long id, 
+			@PathVariable Long restaurantId, 
 			@Valid @RequestBody UserDto user) {
 		
-		RestaurantDTO restaurant = service.removeManager(id, user);
+		RestaurantDTO restaurant = service.removeManager(restaurantId, user);
 		return buildResponse(restaurant);
 	}
 	

--- a/src/main/java/com/inthebytes/restaurantmanager/control/RestaurantAccountController.java
+++ b/src/main/java/com/inthebytes/restaurantmanager/control/RestaurantAccountController.java
@@ -1,5 +1,7 @@
 package com.inthebytes.restaurantmanager.control;
 
+import javax.validation.Valid;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -31,7 +33,7 @@ public class RestaurantAccountController {
 	@PutMapping(value = "/{restaurantId}/managers")
 	public ResponseEntity<RestaurantDTO> addManager(
 			@PathVariable Long id, 
-			@RequestBody UserDto user) {
+			@Valid @RequestBody UserDto user) {
 		
 		RestaurantDTO restaurant = service.addManager(id, user);
 		return buildResponse(restaurant);
@@ -51,7 +53,7 @@ public class RestaurantAccountController {
 	@DeleteMapping(value = "/{restaurantId}/managers")
 	public ResponseEntity<RestaurantDTO> deleteManager(
 			@PathVariable Long id, 
-			@RequestBody UserDto user) {
+			@Valid @RequestBody UserDto user) {
 		
 		RestaurantDTO restaurant = service.removeManager(id, user);
 		return buildResponse(restaurant);

--- a/src/main/java/com/inthebytes/restaurantmanager/dto/RestaurantDTO.java
+++ b/src/main/java/com/inthebytes/restaurantmanager/dto/RestaurantDTO.java
@@ -31,6 +31,9 @@ public class RestaurantDTO {
 
 	@Nullable
 	private List<FoodDTO> foods;
+	
+	@Nullable
+	private List<UserDto> managers;
 
 	public Long getRestaurantId() {
 		return restaurantId;
@@ -70,6 +73,14 @@ public class RestaurantDTO {
 
 	public void setFoods(List<FoodDTO> foods) {
 		this.foods = foods;
+	}
+
+	public List<UserDto> getManagers() {
+		return managers;
+	}
+
+	public void setManagers(List<UserDto> managers) {
+		this.managers = managers;
 	}
 
 	@Override

--- a/src/main/java/com/inthebytes/restaurantmanager/dto/RoleDto.java
+++ b/src/main/java/com/inthebytes/restaurantmanager/dto/RoleDto.java
@@ -1,0 +1,61 @@
+package com.inthebytes.restaurantmanager.dto;
+
+import javax.persistence.Id;
+
+import org.springframework.lang.NonNull;
+
+public class RoleDto {
+
+	@Id
+	@NonNull
+	private Long roleId;
+	
+	@NonNull
+	private String name;
+
+	public Long getRoleId() {
+		return roleId;
+	}
+
+	public void setRoleId(Long roleId) {
+		this.roleId = roleId;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((roleId == null) ? 0 : roleId.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		RoleDto other = (RoleDto) obj;
+		if (roleId == null) {
+			if (other.roleId != null)
+				return false;
+		} else if (!roleId.equals(other.roleId))
+			return false;
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return "RoleDto [roleId=" + roleId + ", name=" + name + "]";
+	}
+}

--- a/src/main/java/com/inthebytes/restaurantmanager/dto/UserDto.java
+++ b/src/main/java/com/inthebytes/restaurantmanager/dto/UserDto.java
@@ -1,0 +1,89 @@
+package com.inthebytes.restaurantmanager.dto;
+
+import javax.persistence.Id;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+
+import org.springframework.lang.NonNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.sun.istack.Nullable;
+
+public class UserDto {
+
+	@Id
+	private Long userId;
+	
+	@NonNull
+	private RoleDto role;
+	
+	@NonNull
+	private String username;
+	
+	@NonNull
+	private Boolean isActive;
+	
+	public Long getUserId() {
+		return userId;
+	}
+
+	public void setUserId(Long userId) {
+		this.userId = userId;
+	}
+
+	public RoleDto getRole() {
+		return role;
+	}
+
+	public void setRole(RoleDto role) {
+		this.role = role;
+	}
+
+	public String getUsername() {
+		return username;
+	}
+	
+	public void setUsername(String username) {
+		this.username = username;
+	}
+
+	public Boolean getIsActive() {
+		return isActive;
+	}
+
+	public void setIsActive(Boolean isActive) {
+		this.isActive = isActive;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((userId == null) ? 0 : userId.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		UserDto other = (UserDto) obj;
+		if (userId == null) {
+			if (other.userId != null)
+				return false;
+		} else if (!userId.equals(other.userId))
+			return false;
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return "UserDto [userId=" + userId + ", role=" + role + ", username=" + username
+				+ ", isActive=" + isActive + "]";
+	}
+	
+}

--- a/src/main/java/com/inthebytes/restaurantmanager/entity/Restaurant.java
+++ b/src/main/java/com/inthebytes/restaurantmanager/entity/Restaurant.java
@@ -11,6 +11,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
@@ -38,6 +39,12 @@ public class Restaurant implements Serializable {
 
 	@OneToMany(mappedBy = "restaurant", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Food> foods;
+	
+	@OneToMany
+	@JoinTable(name = "manager",
+			joinColumns = {@JoinColumn(name = "restaurant_id")},
+			inverseJoinColumns = {@JoinColumn(name = "user_id")})
+	private List<User> manager;
 
 	public Long getRestaurantId() {
 		return restaurantId;
@@ -77,6 +84,14 @@ public class Restaurant implements Serializable {
 
 	public void setFoods(List<Food> foods) {
 		this.foods = foods;
+	}
+
+	public List<User> getManager() {
+		return manager;
+	}
+
+	public void setManager(List<User> manager) {
+		this.manager = manager;
 	}
 
 	public static long getSerialversionuid() {

--- a/src/main/java/com/inthebytes/restaurantmanager/entity/Role.java
+++ b/src/main/java/com/inthebytes/restaurantmanager/entity/Role.java
@@ -1,0 +1,54 @@
+package com.inthebytes.restaurantmanager.entity;
+
+import javax.persistence.Basic;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+public class Role {
+	@Id
+	@GeneratedValue(strategy= GenerationType.IDENTITY)
+	@Column(name = "role_id", nullable = false)
+	private Long roleId;
+
+	@Basic
+	@Column(name = "name", nullable = false, length = 45)
+	private String name;
+
+	public Long getRoleId() {
+		return roleId;
+	}
+	public void setRoleId(Long roleId) {
+		this.roleId = roleId;
+	}
+
+	public String getName() {
+		return name;
+	}
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		Role role = (Role) o;
+
+		if (roleId != null ? !roleId.equals(role.roleId) : role.roleId != null) return false;
+		if (name != null ? !name.equals(role.name) : role.name != null) return false;
+
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = roleId != null ? roleId.hashCode() : 0;
+		result = 31 * result + (name != null ? name.hashCode() : 0);
+		return result;
+	}
+}

--- a/src/main/java/com/inthebytes/restaurantmanager/entity/User.java
+++ b/src/main/java/com/inthebytes/restaurantmanager/entity/User.java
@@ -1,0 +1,146 @@
+package com.inthebytes.restaurantmanager.entity;
+
+import javax.persistence.Basic;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+@Entity
+public class User {
+
+	@Id
+	@GeneratedValue(strategy= GenerationType.IDENTITY)
+	@Column(name = "user_id", nullable = false)
+	private Long userId;
+
+	@Basic
+	@Column(name = "username", nullable = false, length = 45)
+	private String username;
+
+	@Basic
+	@Column(name = "password", nullable = false, length = 81)
+	private String password;
+
+	@Basic
+	@Column(name = "email", nullable = false, length = 45)
+	private String email;
+
+	@Basic
+	@Column(name = "phone", nullable = false, length = 45)
+	private String phone;
+
+	@Basic
+	@Column(name = "first_name", nullable = false, length = 45)
+	private String firstName;
+
+	@Basic
+	@Column(name = "last_name", nullable = false, length = 45)
+	private String lastName;
+
+	@Basic
+	@Column(name = "active", nullable = false)
+	private Boolean active;
+
+	@ManyToOne
+	@JoinColumn(name = "user_role", referencedColumnName = "role_id", nullable = false)
+	private Role role;
+
+	public Long getUserId() {
+		return userId;
+	}
+	public void setUserId(Long userId) {
+		this.userId = userId;
+	}
+
+	public String getUsername() {
+		return username;
+	}
+	public void setUsername(String username) {
+		this.username = username;
+	}
+
+	public String getPassword() {
+		return password;
+	}
+	public void setPassword(String password) {
+		this.password = password;
+	}
+
+	public String getEmail() {
+		return email;
+	}
+	public void setEmail(String email) {
+		this.email = email;
+	}
+
+	public String getPhone() {
+		return phone;
+	}
+	public void setPhone(String phone) {
+		this.phone = phone;
+	}
+
+	public String getFirstName() {
+		return firstName;
+	}
+	public void setFirstName(String firstName) {
+		this.firstName = firstName;
+	}
+
+	public String getLastName() {
+		return lastName;
+	}
+	public void setLastName(String lastName) {
+		this.lastName = lastName;
+	}
+
+	public Boolean getActive() {
+		return active;
+	}
+	public void setActive(Boolean active) {
+		this.active = active;
+	}
+
+	public Role getRole() {
+		return role;
+	}
+	public void setRole(Role role) {
+		this.role = role;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		User user = (User) o;
+
+		if (userId != null ? !userId.equals(user.userId) : user.userId != null) return false;
+		if (username != null ? !username.equals(user.username) : user.username != null) return false;
+		if (password != null ? !password.equals(user.password) : user.password != null) return false;
+		if (email != null ? !email.equals(user.email) : user.email != null) return false;
+		if (phone != null ? !phone.equals(user.phone) : user.phone != null) return false;
+		if (firstName != null ? !firstName.equals(user.firstName) : user.firstName != null) return false;
+		if (lastName != null ? !lastName.equals(user.lastName) : user.lastName != null) return false;
+		if (active != null ? !active.equals(user.active) : user.active != null) return false;
+
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = userId != null ? userId.hashCode() : 0;
+		result = 31 * result + (username != null ? username.hashCode() : 0);
+		result = 31 * result + (password != null ? password.hashCode() : 0);
+		result = 31 * result + (email != null ? email.hashCode() : 0);
+		result = 31 * result + (phone != null ? phone.hashCode() : 0);
+		result = 31 * result + (firstName != null ? firstName.hashCode() : 0);
+		result = 31 * result + (lastName != null ? lastName.hashCode() : 0);
+		result = 31 * result + (active != null ? active.hashCode() : 0);
+		return result;
+	}
+}

--- a/src/main/java/com/inthebytes/restaurantmanager/mapper/RestaurantMapper.java
+++ b/src/main/java/com/inthebytes/restaurantmanager/mapper/RestaurantMapper.java
@@ -3,17 +3,22 @@ package com.inthebytes.restaurantmanager.mapper;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.inthebytes.restaurantmanager.dto.FoodDTO;
 import com.inthebytes.restaurantmanager.dto.LocationDTO;
 import com.inthebytes.restaurantmanager.dto.RestaurantDTO;
+import com.inthebytes.restaurantmanager.dto.UserDto;
 import com.inthebytes.restaurantmanager.entity.Food;
 import com.inthebytes.restaurantmanager.entity.Location;
 import com.inthebytes.restaurantmanager.entity.Restaurant;
 
 @Component
 public class RestaurantMapper {
+	
+	@Autowired
+	UserMapper mapper;
 	
 	public Restaurant convert(RestaurantDTO dto) {
 		Restaurant entity = new Restaurant();
@@ -47,13 +52,21 @@ public class RestaurantMapper {
 		
 		if (entity.getFoods() == null)
 			return dto;
+		
 		List<FoodDTO> foods = new ArrayList<FoodDTO>();
-		for (Food food : entity.getFoods()) {
-			FoodDTO f = convert(food);
-			f.setRestaurant(dto);
-			foods.add(f);
-		}
+		entity.getFoods().stream().forEach((x) -> {
+			FoodDTO food = convert(x);
+			food.setRestaurant(dto);
+			foods.add(food);
+		});
 		dto.setFoods(foods);
+		
+		List<UserDto> managers = new ArrayList<UserDto>();
+		entity.getManager().stream().forEach((x) -> {
+			UserDto manager = mapper.convert(x);
+			managers.add(manager);
+		});
+		dto.setManagers(managers);
 		
 		return dto;
 	}

--- a/src/main/java/com/inthebytes/restaurantmanager/mapper/UserMapper.java
+++ b/src/main/java/com/inthebytes/restaurantmanager/mapper/UserMapper.java
@@ -1,0 +1,29 @@
+package com.inthebytes.restaurantmanager.mapper;
+
+import org.springframework.stereotype.Component;
+
+import com.inthebytes.restaurantmanager.dto.RoleDto;
+import com.inthebytes.restaurantmanager.dto.UserDto;
+import com.inthebytes.restaurantmanager.entity.Role;
+import com.inthebytes.restaurantmanager.entity.User;
+
+@Component
+public class UserMapper {
+	
+	public UserDto convert(User user) {
+		UserDto result = new UserDto();
+		result.setUserId(user.getUserId());
+		result.setUsername(user.getUsername());
+		result.setIsActive(user.getActive());
+		result.setRole(convert(user.getRole()));
+		return result;
+	}
+	
+	public RoleDto convert(Role role) {
+		RoleDto result = new RoleDto();
+		result.setRoleId(role.getRoleId());
+		result.setName(role.getName());
+		return result;
+	}
+
+}

--- a/src/main/java/com/inthebytes/restaurantmanager/mapper/UserMapper.java
+++ b/src/main/java/com/inthebytes/restaurantmanager/mapper/UserMapper.java
@@ -11,6 +11,12 @@ import com.inthebytes.restaurantmanager.entity.User;
 public class UserMapper {
 	
 	public UserDto convert(User user) {
+		if (user == null ||
+				user.getUserId() == null ||
+				user.getUsername() == null ||
+				user.getRole() == null ||
+				user.getActive() == null)
+			return null;
 		UserDto result = new UserDto();
 		result.setUserId(user.getUserId());
 		result.setUsername(user.getUsername());
@@ -20,6 +26,10 @@ public class UserMapper {
 	}
 	
 	public RoleDto convert(Role role) {
+		if (role == null ||
+				role.getRoleId() == null ||
+				role.getName() == null)	
+			return null;
 		RoleDto result = new RoleDto();
 		result.setRoleId(role.getRoleId());
 		result.setName(role.getName());

--- a/src/main/java/com/inthebytes/restaurantmanager/repository/RestaurantDao.java
+++ b/src/main/java/com/inthebytes/restaurantmanager/repository/RestaurantDao.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Repository;
 import com.inthebytes.restaurantmanager.entity.Restaurant;
 
 @Repository
-public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
+public interface RestaurantDao extends JpaRepository<Restaurant, Long> {
 	Restaurant findByRestaurantId(Long id);
 	Restaurant findByName(String name);
 }

--- a/src/main/java/com/inthebytes/restaurantmanager/repository/RoleDao.java
+++ b/src/main/java/com/inthebytes/restaurantmanager/repository/RoleDao.java
@@ -1,0 +1,11 @@
+package com.inthebytes.restaurantmanager.repository;
+
+import com.inthebytes.restaurantmanager.entity.Role;
+import com.inthebytes.restaurantmanager.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoleDao extends JpaRepository<Role, Long> {
+	Role findByName(String roleName);
+}

--- a/src/main/java/com/inthebytes/restaurantmanager/repository/UserDao.java
+++ b/src/main/java/com/inthebytes/restaurantmanager/repository/UserDao.java
@@ -1,0 +1,17 @@
+package com.inthebytes.restaurantmanager.repository;
+
+import com.inthebytes.restaurantmanager.entity.User;
+
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+@Repository
+public interface UserDao extends JpaRepository<User, Long> {
+	User findByEmailIgnoreCase(String email);
+	List<User> findAll();
+	User findByUsername(String username);
+	User findByUserId(Long userId);
+}

--- a/src/main/java/com/inthebytes/restaurantmanager/service/RestaurantAccountService.java
+++ b/src/main/java/com/inthebytes/restaurantmanager/service/RestaurantAccountService.java
@@ -13,7 +13,7 @@ import com.inthebytes.restaurantmanager.repository.RestaurantDao;
 import com.inthebytes.restaurantmanager.repository.RoleDao;
 import com.inthebytes.restaurantmanager.repository.UserDao;
 
-public class RestaurantManagerService {
+public class RestaurantAccountService {
 	
 	@Autowired
 	private RestaurantDao restaurantRepo;

--- a/src/main/java/com/inthebytes/restaurantmanager/service/RestaurantAccountService.java
+++ b/src/main/java/com/inthebytes/restaurantmanager/service/RestaurantAccountService.java
@@ -44,7 +44,7 @@ public class RestaurantAccountService {
 		Restaurant restaurant = restaurantRepo.findByRestaurantId(restaurantId);
 		User userEntity = userRepo.findByUsername(user.getUsername());
 		
-		if (userEntity == null)
+		if (userEntity == null || restaurant == null)
 			return null;
 		userEntity.setRole(findManagerRole());
 		userEntity.setActive(true);
@@ -65,7 +65,7 @@ public class RestaurantAccountService {
 	public RestaurantDTO removeManager(Long restaurantId, UserDto user) {
 		Restaurant restaurant = restaurantRepo.findByRestaurantId(restaurantId);
 		User userEntity = userRepo.findByUsername(user.getUsername());
-		if (userEntity == null)
+		if (userEntity == null || restaurant == null)
 			return null;
 		
 		userEntity.setActive(false);

--- a/src/main/java/com/inthebytes/restaurantmanager/service/RestaurantAccountService.java
+++ b/src/main/java/com/inthebytes/restaurantmanager/service/RestaurantAccountService.java
@@ -1,6 +1,7 @@
 package com.inthebytes.restaurantmanager.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import com.inthebytes.restaurantmanager.dto.RestaurantDTO;
 import com.inthebytes.restaurantmanager.dto.UserDto;
@@ -13,6 +14,7 @@ import com.inthebytes.restaurantmanager.repository.RestaurantDao;
 import com.inthebytes.restaurantmanager.repository.RoleDao;
 import com.inthebytes.restaurantmanager.repository.UserDao;
 
+@Service
 public class RestaurantAccountService {
 	
 	@Autowired

--- a/src/main/java/com/inthebytes/restaurantmanager/service/RestaurantManagerService.java
+++ b/src/main/java/com/inthebytes/restaurantmanager/service/RestaurantManagerService.java
@@ -2,7 +2,13 @@ package com.inthebytes.restaurantmanager.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
+import com.inthebytes.restaurantmanager.dto.RestaurantDTO;
+import com.inthebytes.restaurantmanager.dto.UserDto;
+import com.inthebytes.restaurantmanager.entity.Restaurant;
+import com.inthebytes.restaurantmanager.entity.Role;
+import com.inthebytes.restaurantmanager.entity.User;
 import com.inthebytes.restaurantmanager.mapper.RestaurantMapper;
+import com.inthebytes.restaurantmanager.mapper.UserMapper;
 import com.inthebytes.restaurantmanager.repository.RestaurantDao;
 import com.inthebytes.restaurantmanager.repository.RoleDao;
 import com.inthebytes.restaurantmanager.repository.UserDao;
@@ -20,5 +26,60 @@ public class RestaurantManagerService {
 	
 	@Autowired
 	private RestaurantMapper restaurantMapper;
+	
+	@Autowired
+	private UserMapper userMapper;
+	
+	private Role findManagerRole() {
+		Role role = roleRepo.findByName("restaurant");
+		if (role != null)
+			return role;
+		role = roleRepo.findByName("manager");
+		return role;
+	}
+	
+	public RestaurantDTO addManager(Long restaurantId, UserDto user) {
+		Restaurant restaurant = restaurantRepo.findByRestaurantId(restaurantId);
+		User userEntity = userRepo.findByUsername(user.getUsername());
+		
+		if (userEntity == null)
+			return null;
+		userEntity.setRole(findManagerRole());
+		userEntity.setActive(true);
+		userEntity = userRepo.save(userEntity);
+		
+		restaurant.getManager().add(userEntity);
+		return restaurantMapper.convert(restaurantRepo.save(restaurant));
+		
+	}
+	
+	public RestaurantDTO addManager(Long restaurantId, Long userId) {
+		User userEntity = userRepo.findByUserId(userId);
+		if (userEntity == null)
+			return null;
+		return addManager(restaurantId, userMapper.convert(userEntity));
+	}
+	
+	public RestaurantDTO removeManager(Long restaurantId, UserDto user) {
+		Restaurant restaurant = restaurantRepo.findByRestaurantId(restaurantId);
+		User userEntity = userRepo.findByUsername(user.getUsername());
+		if (userEntity == null)
+			return null;
+		
+		userEntity.setActive(false);
+		userEntity = userRepo.save(userEntity);
+		
+		if (restaurant.getManager().remove(userEntity)) {
+			return restaurantMapper.convert(restaurantRepo.save(restaurant));
+		}
+		return null;
+	}
+	
+	public RestaurantDTO removeManager(Long restaurantId, Long userId) {
+		User userEntity = userRepo.findByUserId(userId);
+		if (userEntity == null)
+			return null;
+		return removeManager(restaurantId, userMapper.convert(userEntity));
+	}
 
 }

--- a/src/main/java/com/inthebytes/restaurantmanager/service/RestaurantManagerService.java
+++ b/src/main/java/com/inthebytes/restaurantmanager/service/RestaurantManagerService.java
@@ -1,0 +1,24 @@
+package com.inthebytes.restaurantmanager.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.inthebytes.restaurantmanager.mapper.RestaurantMapper;
+import com.inthebytes.restaurantmanager.repository.RestaurantDao;
+import com.inthebytes.restaurantmanager.repository.RoleDao;
+import com.inthebytes.restaurantmanager.repository.UserDao;
+
+public class RestaurantManagerService {
+	
+	@Autowired
+	private RestaurantDao restaurantRepo;
+	
+	@Autowired
+	private RoleDao roleRepo;
+	
+	@Autowired
+	private UserDao userRepo;
+	
+	@Autowired
+	private RestaurantMapper restaurantMapper;
+
+}

--- a/src/main/java/com/inthebytes/restaurantmanager/service/RestaurantService.java
+++ b/src/main/java/com/inthebytes/restaurantmanager/service/RestaurantService.java
@@ -13,13 +13,13 @@ import org.springframework.stereotype.Service;
 import com.inthebytes.restaurantmanager.dto.RestaurantDTO;
 import com.inthebytes.restaurantmanager.entity.Restaurant;
 import com.inthebytes.restaurantmanager.mapper.RestaurantMapper;
-import com.inthebytes.restaurantmanager.repository.RestaurantRepository;
+import com.inthebytes.restaurantmanager.repository.RestaurantDao;
 
 @Service
 public class RestaurantService {
 
 	@Autowired
-	private RestaurantRepository restaurantRepo;
+	private RestaurantDao restaurantRepo;
 
 	@Autowired
 	private RestaurantMapper mapper;

--- a/src/test/java/com/inthebytes/restaurantmanager/control/RestaurantAccountControllerTest.java
+++ b/src/test/java/com/inthebytes/restaurantmanager/control/RestaurantAccountControllerTest.java
@@ -1,0 +1,159 @@
+package com.inthebytes.restaurantmanager.control;
+
+import static org.hamcrest.CoreMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.aspectj.lang.annotation.Before;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.inthebytes.restaurantmanager.dto.FoodDTO;
+import com.inthebytes.restaurantmanager.dto.LocationDTO;
+import com.inthebytes.restaurantmanager.dto.RestaurantDTO;
+import com.inthebytes.restaurantmanager.dto.RoleDto;
+import com.inthebytes.restaurantmanager.dto.UserDto;
+import com.inthebytes.restaurantmanager.service.RestaurantAccountService;
+
+@WebMvcTest(controllers = RestaurantAccountController.class)
+@AutoConfigureMockMvc
+@TestInstance(Lifecycle.PER_CLASS)
+public class RestaurantAccountControllerTest {
+	
+	@MockBean
+	RestaurantAccountService service;
+	
+	@Autowired
+	MockMvc mock;
+	
+	private UserDto manager;
+	
+	private void makeUser() {
+		UserDto user = new UserDto();
+		user.setUserId(1L);
+		user.setUsername("TestUser");
+		user.setIsActive(true);
+		RoleDto role = new RoleDto();
+		role.setRoleId(1L);
+		role.setName("test");
+		user.setRole(role);
+		manager = user;
+	}
+	
+	private RestaurantDTO makeRestaurant(Boolean addManager) {
+		LocationDTO location = new LocationDTO("Test", "Test", "Test", "Test", 11111);
+		RestaurantDTO restaurant = new RestaurantDTO("Test", "Test", location);
+		restaurant.setFoods(new ArrayList<FoodDTO>());
+		restaurant.setRestaurantId((addManager) ? 1L : 2L);
+		List<UserDto> managers = new ArrayList<UserDto>();
+		if (addManager)
+			managers.add(manager);
+		restaurant.setManagers(managers);
+		return restaurant;
+		
+	}
+	
+	@BeforeAll
+	public void setUp() {
+		makeUser();
+	}
+	
+	@Test
+	public void addManagerTest() throws Exception {
+		Mockito.when(service.addManager(1L, manager)).thenReturn(makeRestaurant(true));
+		
+		mock.perform(put("/apis/restaurants/1/managers")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(new ObjectMapper().writeValueAsString(manager)))
+		.andExpect(MockMvcResultMatchers.status().isOk())
+		.andExpect(jsonPath("$.restaurantId").value(1L))
+		.andExpect(jsonPath("$.managers").isNotEmpty());
+	}
+	
+	@Test
+	public void addManagerNotFoundTest() throws Exception {
+		mock.perform(put("/apis/restaurants/2/managers")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(new ObjectMapper().writeValueAsString(manager)))
+		.andExpect(MockMvcResultMatchers.status().isNotFound());
+	}
+	
+	
+	@Test
+	public void addManagerByIdTest() throws Exception {
+		Mockito.when(service.addManager(1L, 1L)).thenReturn(makeRestaurant(true));
+		
+		mock.perform(put("/apis/restaurants/1/managers/1")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(new ObjectMapper().writeValueAsString(manager)))
+		.andExpect(MockMvcResultMatchers.status().isOk())
+		.andExpect(jsonPath("$.restaurantId").value(1L))
+		.andExpect(jsonPath("$.managers").isNotEmpty());
+	}
+	
+	@Test
+	public void addManagerByIdNotFoundTest() throws Exception {
+		mock.perform(put("/apis/restaurants/2/managers/1")
+				.contentType(MediaType.APPLICATION_JSON))
+		.andExpect(MockMvcResultMatchers.status().isNotFound());
+	}
+	
+	
+	@Test
+	public void deleteManagerTest() throws Exception {
+		Mockito.when(service.removeManager(2L, manager)).thenReturn(makeRestaurant(false));
+		
+		mock.perform(delete("/apis/restaurants/2/managers")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(new ObjectMapper().writeValueAsString(manager)))
+		.andExpect(MockMvcResultMatchers.status().isOk())
+		.andExpect(jsonPath("$.restaurantId").value(2L))
+		.andExpect(jsonPath("$.managers").isEmpty());
+	}
+	
+	@Test
+	public void deleteManagerNotFoundTest() throws Exception {
+		mock.perform(delete("/apis/restaurants/2/managers")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(new ObjectMapper().writeValueAsString(manager)))
+		.andExpect(MockMvcResultMatchers.status().isNotFound());
+	}
+	
+	
+	@Test
+	public void deleteManagerByIdTest() throws Exception {
+		Mockito.when(service.removeManager(2L, 1L)).thenReturn(makeRestaurant(false));
+		
+		mock.perform(delete("/apis/restaurants/2/managers/1")
+				.contentType(MediaType.APPLICATION_JSON))
+		.andExpect(MockMvcResultMatchers.status().isOk())
+		.andExpect(jsonPath("$.restaurantId").value(2L))
+		.andExpect(jsonPath("$.managers").isEmpty());
+	}
+	
+	@Test
+	public void deleteManagerByIdNotFoundTest() throws Exception {
+		mock.perform(delete("/apis/restaurants/2/managers/1")
+				.contentType(MediaType.APPLICATION_JSON))
+		.andExpect(MockMvcResultMatchers.status().isNotFound());
+	}
+
+}

--- a/src/test/java/com/inthebytes/restaurantmanager/mapper/RestaurantMapperTest.java
+++ b/src/test/java/com/inthebytes/restaurantmanager/mapper/RestaurantMapperTest.java
@@ -16,6 +16,7 @@ import com.inthebytes.restaurantmanager.dto.RestaurantDTO;
 import com.inthebytes.restaurantmanager.entity.Food;
 import com.inthebytes.restaurantmanager.entity.Location;
 import com.inthebytes.restaurantmanager.entity.Restaurant;
+import com.inthebytes.restaurantmanager.entity.User;
 
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -111,6 +112,9 @@ public class RestaurantMapperTest {
 		List<Food> foods = new ArrayList<Food>();
 		foods.add(food);
 		test.setFoods(foods);
+		
+		List<User> managers = new ArrayList<User>();
+		test.setManager(managers);
 
 		return test;
 	}

--- a/src/test/java/com/inthebytes/restaurantmanager/mapper/UserMapperTest.java
+++ b/src/test/java/com/inthebytes/restaurantmanager/mapper/UserMapperTest.java
@@ -1,0 +1,91 @@
+package com.inthebytes.restaurantmanager.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.inthebytes.restaurantmanager.dto.RoleDto;
+import com.inthebytes.restaurantmanager.dto.UserDto;
+import com.inthebytes.restaurantmanager.entity.Role;
+import com.inthebytes.restaurantmanager.entity.User;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@TestInstance(Lifecycle.PER_CLASS)
+public class UserMapperTest {
+
+	@Autowired 
+	UserMapper mapper;
+	
+	private User userEntity;
+	private UserDto userDto;
+	
+	private void makeDto() {
+		userDto = new UserDto();
+		RoleDto role = new RoleDto();
+		role.setRoleId(1L);
+		role.setName("Test");
+		userDto.setRole(role);
+		userDto.setUserId(1L);
+		userDto.setUsername("Test");
+		userDto.setIsActive(true);
+	}
+	
+	private void makeEntity() {
+		userEntity = new User();
+		Role role = new Role();
+		role.setRoleId(1L);
+		role.setName("Test");
+		userEntity.setRole(role);
+		userEntity.setUserId(1L);
+		userEntity.setUsername("Test");
+		userEntity.setActive(true);
+	}
+	
+	@BeforeAll
+	public void setUp() {
+		makeDto();
+		makeEntity();
+	}
+	
+	@Test
+	public void userConvertTest() {
+		assertThat(mapper.convert(userEntity)).isEqualTo(userDto);
+	}
+	
+	@Test
+	public void nullUserConvertTest() {
+		User user = null;
+		assertThat(mapper.convert(user)).isNull();
+	}
+	
+	@Test
+	public void emptyUserConvertTest() {
+		User user = new User();
+		assertThat(mapper.convert(user)).isNull();
+	}
+	
+	@Test
+	public void roleConvertTest() {
+		assertThat(mapper.convert(userEntity.getRole())).isEqualTo(userDto.getRole());
+	}
+	
+	@Test
+	public void nullRoleConvertTest() {
+		Role role = null;
+		assertThat(mapper.convert(role)).isNull();
+	}
+	
+	@Test
+	public void emptyRoleConvertTest() {
+		Role role = new Role();
+		assertThat(mapper.convert(role)).isNull();
+	}
+}

--- a/src/test/java/com/inthebytes/restaurantmanager/service/RestaurantAccountServiceTest.java
+++ b/src/test/java/com/inthebytes/restaurantmanager/service/RestaurantAccountServiceTest.java
@@ -1,12 +1,19 @@
 package com.inthebytes.restaurantmanager.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
+
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -25,6 +32,7 @@ import com.inthebytes.restaurantmanager.repository.RoleDao;
 import com.inthebytes.restaurantmanager.repository.UserDao;
 
 @RunWith(MockitoJUnitRunner.class)
+@TestInstance(Lifecycle.PER_CLASS)
 public class RestaurantAccountServiceTest {
 
 	@Mock
@@ -45,137 +53,203 @@ public class RestaurantAccountServiceTest {
 	@InjectMocks
 	RestaurantAccountService service;
 	
-	@BeforeEach
+	private Restaurant restaurantEntity;
+	private User managerEntity;
+	private RestaurantDTO restaurantDto;
+	private UserDto userDto;
+
+	private Role getRole(Boolean isManager) {
+		Role role = new Role();
+		role.setRoleId((isManager) ? 1L : 2L);
+		role.setName((isManager) ? "restaurant" : "user");
+		return role;
+	}
+	
+	private void initializeUsers() {
+		managerEntity = new User();
+		managerEntity.setUserId(1L);
+		
+		userDto = new UserDto();
+		userDto.setUserId(1L);
+		userDto.setUsername("Test");
+		userDto.setIsActive(false);
+		RoleDto role = new RoleDto();
+		role.setRoleId(2L);
+		role.setName("user");
+		userDto.setRole(role);
+	}
+	
+	private void initializeRestaurants() {
+		restaurantEntity = new Restaurant();
+		restaurantEntity.setRestaurantId(1L);
+		restaurantEntity.setName("Test Restaurant");
+		restaurantEntity.setManager(new ArrayList<User>());
+		
+		LocationDTO location = new LocationDTO("", "", "", "", 11111);
+		restaurantDto = new RestaurantDTO("Test Restuarant", "Test", location);
+		restaurantDto.setRestaurantId(1L);
+	}
+	
+	@BeforeAll
 	public void setUp() {
+		initializeUsers();
+		initializeRestaurants();
+	}
+	
+	@BeforeEach
+	public void init() {
 		MockitoAnnotations.initMocks(this);
-		when(roleRepo.findByName("restaurant")).thenReturn(getRole(true));
-		when(userMapper.convert(makeManager(true))).thenReturn(makeManagerDto());
 	}
 	
 	@Test
 	public void addManagerWithDtoTest() {
+		when(roleRepo.findByName("restaurant")).thenReturn(getRole(true));
+		when(restaurantRepo.findByRestaurantId(1L)).thenReturn(restaurantEntity);
+		when(userRepo.findByUsername("Test")).thenReturn(managerEntity);
+		when(userRepo.save(managerEntity)).thenReturn(managerEntity);
+		when(restaurantRepo.save(restaurantEntity)).thenReturn(restaurantEntity);
+		when(restaurantMapper.convert(restaurantEntity)).thenReturn(restaurantDto);
 		
+		assertThat(service.addManager(1L, userDto)).isEqualTo(restaurantDto);
 	}
 	
 	@Test
 	public void addManagerDtoNoUserTest() {
+		when(roleRepo.findByName("restaurant")).thenReturn(getRole(true));
+		when(restaurantRepo.findByRestaurantId(1L)).thenReturn(restaurantEntity);
+		when(userRepo.findByUsername("Test")).thenReturn(null);
+		when(userRepo.save(managerEntity)).thenReturn(managerEntity);
+		when(restaurantRepo.save(restaurantEntity)).thenReturn(restaurantEntity);
+		when(restaurantMapper.convert(restaurantEntity)).thenReturn(restaurantDto);
 		
+		assertThat(service.addManager(1L, userDto)).isNull();
 	}
 	
 	@Test
 	public void addManagerDtoNoRestaurantTest() {
+		when(roleRepo.findByName("restaurant")).thenReturn(getRole(true));
+		when(restaurantRepo.findByRestaurantId(1L)).thenReturn(null);
+		when(userRepo.findByUsername("Test")).thenReturn(managerEntity);
+		when(userRepo.save(managerEntity)).thenReturn(managerEntity);
+		when(restaurantRepo.save(restaurantEntity)).thenReturn(restaurantEntity);
+		when(restaurantMapper.convert(restaurantEntity)).thenReturn(restaurantDto);
+		when(userRepo.findByUserId(1L)).thenReturn(managerEntity);
+		when(userMapper.convert(managerEntity)).thenReturn(userDto);
 		
+		assertThat(service.addManager(1L, userDto)).isNull();
 	}
 	
 	@Test
 	public void addManagerWithIdTest() {
+		when(roleRepo.findByName("restaurant")).thenReturn(getRole(true));
+		when(restaurantRepo.findByRestaurantId(1L)).thenReturn(restaurantEntity);
+		when(userRepo.findByUsername("Test")).thenReturn(managerEntity);
+		when(userRepo.save(managerEntity)).thenReturn(managerEntity);
+		when(restaurantRepo.save(restaurantEntity)).thenReturn(restaurantEntity);
+		when(restaurantMapper.convert(restaurantEntity)).thenReturn(restaurantDto);
+		when(userRepo.findByUserId(1L)).thenReturn(managerEntity);
+		when(userMapper.convert(managerEntity)).thenReturn(userDto);
 		
+		assertThat(service.addManager(1L, 1L)).isEqualTo(restaurantDto);
 	}
 	
 	@Test
 	public void addManagerIdNoUserTest() {
+		when(roleRepo.findByName("restaurant")).thenReturn(getRole(true));
+		when(restaurantRepo.findByRestaurantId(1L)).thenReturn(restaurantEntity);
+		when(userRepo.findByUsername("Test")).thenReturn(null);
+		when(userRepo.save(managerEntity)).thenReturn(managerEntity);
+		when(restaurantRepo.save(restaurantEntity)).thenReturn(restaurantEntity);
+		when(restaurantMapper.convert(restaurantEntity)).thenReturn(restaurantDto);
+		when(userRepo.findByUserId(1L)).thenReturn(managerEntity);
+		when(userMapper.convert(managerEntity)).thenReturn(userDto);
 		
+		assertThat(service.addManager(1L, 1L)).isNull();
 	}
 	
 	@Test
 	public void addManagerIdNoRestaurantTest() {
+		when(roleRepo.findByName("restaurant")).thenReturn(getRole(true));
+		when(restaurantRepo.findByRestaurantId(1L)).thenReturn(null);
+		when(userRepo.findByUsername("Test")).thenReturn(managerEntity);
+		when(userRepo.save(managerEntity)).thenReturn(managerEntity);
+		when(restaurantRepo.save(restaurantEntity)).thenReturn(restaurantEntity);
+		when(restaurantMapper.convert(restaurantEntity)).thenReturn(restaurantDto);
+		when(userRepo.findByUserId(1L)).thenReturn(managerEntity);
+		when(userMapper.convert(managerEntity)).thenReturn(userDto);
 		
+		assertThat(service.addManager(1L, 1L)).isNull();
 	}
 	
 	@Test
 	public void removeManagerWithDtoTest() {
+		when(restaurantRepo.findByRestaurantId(1L)).thenReturn(restaurantEntity);
+		when(userRepo.findByUsername("Test")).thenReturn(managerEntity);
+		when(userRepo.save(managerEntity)).thenReturn(managerEntity);
+		when(restaurantRepo.save(restaurantEntity)).thenReturn(restaurantEntity);
+		when(restaurantMapper.convert(restaurantEntity)).thenReturn(restaurantDto);
 		
+		assertThat(service.removeManager(1L, userDto)).isEqualTo(restaurantDto);
 	}
 	
 	@Test
 	public void removeManagerDtoNoUserTest() {
+		when(restaurantRepo.findByRestaurantId(1L)).thenReturn(restaurantEntity);
+		when(userRepo.findByUsername("Test")).thenReturn(null);
+		when(userRepo.save(managerEntity)).thenReturn(managerEntity);
+		when(restaurantRepo.save(restaurantEntity)).thenReturn(restaurantEntity);
+		when(restaurantMapper.convert(restaurantEntity)).thenReturn(restaurantDto);
 		
+		assertThat(service.removeManager(1L, userDto)).isNull();
 	}
 	
 	@Test
 	public void removeManagerDtoNoRestaurantTest() {
+		when(restaurantRepo.findByRestaurantId(1L)).thenReturn(null);
+		when(userRepo.findByUsername("Test")).thenReturn(managerEntity);
+		when(userRepo.save(managerEntity)).thenReturn(managerEntity);
+		when(restaurantRepo.save(restaurantEntity)).thenReturn(restaurantEntity);
+		when(restaurantMapper.convert(restaurantEntity)).thenReturn(restaurantDto);
 		
+		assertThat(service.removeManager(1L, userDto)).isNull();
 	}
 	
 	@Test
 	public void removeManagerWithIdTest() {
+		when(restaurantRepo.findByRestaurantId(1L)).thenReturn(restaurantEntity);
+		when(userRepo.findByUsername("Test")).thenReturn(managerEntity);
+		when(userRepo.save(managerEntity)).thenReturn(managerEntity);
+		when(restaurantRepo.save(restaurantEntity)).thenReturn(restaurantEntity);
+		when(restaurantMapper.convert(restaurantEntity)).thenReturn(restaurantDto);
+		when(userRepo.findByUserId(1L)).thenReturn(managerEntity);
+		when(userMapper.convert(managerEntity)).thenReturn(userDto);
 		
+		assertThat(service.removeManager(1L, userDto)).isEqualTo(restaurantDto);
 	}
 	
 	@Test
 	public void removeManagerIdNoUserTest() {
+		when(restaurantRepo.findByRestaurantId(1L)).thenReturn(restaurantEntity);
+		when(userRepo.findByUsername("Test")).thenReturn(null);
+		when(userRepo.save(managerEntity)).thenReturn(managerEntity);
+		when(restaurantRepo.save(restaurantEntity)).thenReturn(restaurantEntity);
+		when(restaurantMapper.convert(restaurantEntity)).thenReturn(restaurantDto);
+		when(userRepo.findByUserId(1L)).thenReturn(null);
+		when(userMapper.convert(managerEntity)).thenReturn(userDto);
 		
+		assertThat(service.removeManager(1L, userDto)).isNull();
 	}
 	
 	@Test
 	public void removeManagerIdNoRestaurantTest() {
+		when(restaurantRepo.findByRestaurantId(1L)).thenReturn(null);
+		when(userRepo.findByUsername("Test")).thenReturn(managerEntity);
+		when(userRepo.save(managerEntity)).thenReturn(managerEntity);
+		when(restaurantRepo.save(restaurantEntity)).thenReturn(restaurantEntity);
+		when(restaurantMapper.convert(restaurantEntity)).thenReturn(restaurantDto);
+		when(userRepo.findByUserId(1L)).thenReturn(managerEntity);
+		when(userMapper.convert(managerEntity)).thenReturn(userDto);
 		
-	}
-	
-	private void happyPath() {
-	}
-	
-
-	private Role getRole(Boolean isManager) {
-		Role role = new Role();
-		role.setRoleId(26L);
-		if (isManager)
-			role.setName("restaurant");
-		else
-			role.setName("user");
-		return role;
-	}
-	
-	private RestaurantDTO makeRestaurantDTO() {
-		LocationDTO location = new LocationDTO("Main St.", "123", "Sacramento", "California", 11111);
-		RestaurantDTO test = new RestaurantDTO("Lexi's Burgers", "Fast Food", location);
-
-		return test;
-	}
-	
-	private Restaurant makeRestaurantEntity(Boolean hasManager) {
-		Restaurant test = new Restaurant();
-		test.setName("Lexi's Burgers");
-
-		Location location = new Location();
-		location.setStreet("Main St.");
-		location.setUnit("123");
-		location.setCity("Sacramento");
-		location.setState("California");
-		location.setZipCode(95838);
-		test.setLocation(location);
-
-		test.setCuisine("Fast Food");
-
-		if (hasManager) {
-			
-		}
-		return test;
-	}
-	
-	private UserDto makeManagerDto() {
-		UserDto manager = new UserDto();
-		manager.setUserId(1L);
-		manager.setUsername("lexnel");
-		RoleDto role = new RoleDto();
-		role.setName("restaurant");
-		role.setRoleId(26L);
-		manager.setRole(role);
-		manager.setIsActive(true);
-		return manager;
-	}
-	
-	private User makeManager(Boolean isActive) {
-		User manager = new User();
-		manager.setUserId(1L);
-		manager.setPassword("password");
-		manager.setUsername("lexnel");
-		manager.setFirstName("Lexi");
-		manager.setLastName("Nelson");
-		manager.setPhone("00000000000");
-		manager.setEmail("email@email.com");
-		manager.setRole(getRole(isActive));
-		manager.setActive(isActive);
-		return manager;
+		assertThat(service.removeManager(1L, userDto)).isNull();
 	}
 }

--- a/src/test/java/com/inthebytes/restaurantmanager/service/RestaurantAccountServiceTest.java
+++ b/src/test/java/com/inthebytes/restaurantmanager/service/RestaurantAccountServiceTest.java
@@ -1,0 +1,181 @@
+package com.inthebytes.restaurantmanager.service;
+
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.inthebytes.restaurantmanager.dto.LocationDTO;
+import com.inthebytes.restaurantmanager.dto.RestaurantDTO;
+import com.inthebytes.restaurantmanager.dto.RoleDto;
+import com.inthebytes.restaurantmanager.dto.UserDto;
+import com.inthebytes.restaurantmanager.entity.Location;
+import com.inthebytes.restaurantmanager.entity.Restaurant;
+import com.inthebytes.restaurantmanager.entity.Role;
+import com.inthebytes.restaurantmanager.entity.User;
+import com.inthebytes.restaurantmanager.mapper.RestaurantMapper;
+import com.inthebytes.restaurantmanager.mapper.UserMapper;
+import com.inthebytes.restaurantmanager.repository.RestaurantDao;
+import com.inthebytes.restaurantmanager.repository.RoleDao;
+import com.inthebytes.restaurantmanager.repository.UserDao;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RestaurantAccountServiceTest {
+
+	@Mock
+	private RestaurantDao restaurantRepo;
+	
+	@Mock
+	private RoleDao roleRepo;
+	
+	@Mock
+	private UserDao userRepo;
+	
+	@Mock
+	private RestaurantMapper restaurantMapper;
+	
+	@Mock
+	private UserMapper userMapper;
+	
+	@InjectMocks
+	RestaurantAccountService service;
+	
+	@BeforeEach
+	public void setUp() {
+		MockitoAnnotations.initMocks(this);
+		when(roleRepo.findByName("restaurant")).thenReturn(getRole(true));
+		when(userMapper.convert(makeManager(true))).thenReturn(makeManagerDto());
+	}
+	
+	@Test
+	public void addManagerWithDtoTest() {
+		
+	}
+	
+	@Test
+	public void addManagerDtoNoUserTest() {
+		
+	}
+	
+	@Test
+	public void addManagerDtoNoRestaurantTest() {
+		
+	}
+	
+	@Test
+	public void addManagerWithIdTest() {
+		
+	}
+	
+	@Test
+	public void addManagerIdNoUserTest() {
+		
+	}
+	
+	@Test
+	public void addManagerIdNoRestaurantTest() {
+		
+	}
+	
+	@Test
+	public void removeManagerWithDtoTest() {
+		
+	}
+	
+	@Test
+	public void removeManagerDtoNoUserTest() {
+		
+	}
+	
+	@Test
+	public void removeManagerDtoNoRestaurantTest() {
+		
+	}
+	
+	@Test
+	public void removeManagerWithIdTest() {
+		
+	}
+	
+	@Test
+	public void removeManagerIdNoUserTest() {
+		
+	}
+	
+	@Test
+	public void removeManagerIdNoRestaurantTest() {
+		
+	}
+	
+	private void happyPath() {
+	}
+	
+
+	private Role getRole(Boolean isManager) {
+		Role role = new Role();
+		role.setRoleId(26L);
+		if (isManager)
+			role.setName("restaurant");
+		else
+			role.setName("user");
+		return role;
+	}
+	
+	private RestaurantDTO makeRestaurantDTO() {
+		LocationDTO location = new LocationDTO("Main St.", "123", "Sacramento", "California", 11111);
+		RestaurantDTO test = new RestaurantDTO("Lexi's Burgers", "Fast Food", location);
+
+		return test;
+	}
+	
+	private Restaurant makeRestaurantEntity(Boolean hasManager) {
+		Restaurant test = new Restaurant();
+		test.setName("Lexi's Burgers");
+
+		Location location = new Location();
+		location.setStreet("Main St.");
+		location.setUnit("123");
+		location.setCity("Sacramento");
+		location.setState("California");
+		location.setZipCode(95838);
+		test.setLocation(location);
+
+		test.setCuisine("Fast Food");
+
+		if (hasManager) {
+			
+		}
+		return test;
+	}
+	
+	private UserDto makeManagerDto() {
+		UserDto manager = new UserDto();
+		manager.setUserId(1L);
+		manager.setUsername("lexnel");
+		RoleDto role = new RoleDto();
+		role.setName("restaurant");
+		role.setRoleId(26L);
+		manager.setRole(role);
+		manager.setIsActive(true);
+		return manager;
+	}
+	
+	private User makeManager(Boolean isActive) {
+		User manager = new User();
+		manager.setUserId(1L);
+		manager.setPassword("password");
+		manager.setUsername("lexnel");
+		manager.setFirstName("Lexi");
+		manager.setLastName("Nelson");
+		manager.setPhone("00000000000");
+		manager.setEmail("email@email.com");
+		manager.setRole(getRole(isActive));
+		manager.setActive(isActive);
+		return manager;
+	}
+}

--- a/src/test/java/com/inthebytes/restaurantmanager/service/RestaurantServiceTest.java
+++ b/src/test/java/com/inthebytes/restaurantmanager/service/RestaurantServiceTest.java
@@ -25,7 +25,7 @@ import com.inthebytes.restaurantmanager.dto.RestaurantDTO;
 import com.inthebytes.restaurantmanager.entity.Location;
 import com.inthebytes.restaurantmanager.entity.Restaurant;
 import com.inthebytes.restaurantmanager.mapper.RestaurantMapper;
-import com.inthebytes.restaurantmanager.repository.RestaurantRepository;
+import com.inthebytes.restaurantmanager.repository.RestaurantDao;
 
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -33,7 +33,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class RestaurantServiceTest {
 
 	@Mock
-	RestaurantRepository repo;
+	RestaurantDao repo;
 	
 	@Mock
 	RestaurantMapper mapper;


### PR DESCRIPTION
Includes a new class RestaurantAccountController

Maps two methods each for PUT and DELETE for manager restaurant user accounts.
Each method is mapped to apis/restaurants/{restaurant-id}/managers and has the option to include the user account in the request body, but also provides a mapping to include a user-id as the final end point for working with accounts that already exist.